### PR TITLE
Double sphere support

### DIFF
--- a/src/dso/util/Undistort.h
+++ b/src/dso/util/Undistort.h
@@ -159,5 +159,17 @@ public:
 
 };
 
+class UndistortDS : public Undistort
+{
+public:
+	EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
+    UndistortDS(const char* configFileName, bool noprefix);
+	~UndistortDS();
+	void distortCoordinates(float* in_x, float* in_y, float* out_x, float* out_y, int n) const;
+
+private:
+	float inputCalibration[8];
+};
+
 }
 


### PR DESCRIPTION
Double sphere support added as per the instructions given by WFram in https://github.com/lukasvst/dm-vio/issues/62
refererring basalt and https://cvg.cit.tum.de/_media/spezial/bib/usenko18double-sphere.pdf research paper