### PR TITLE
Add tsFile parameter for specifying times.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Download a TUM-VI sequence (download in the format `Euroc / DSO 512x512`) at htt
         vignette=XXXX/datasetXXXX/dso/cam0/vignette.png
         imuFile=XXXX/datasetXXXX/dso/imu.txt
         gtFile=XXXX/datasetXXXX/dso/gt_imu.csv
+        tsFile=XXXX/datasetXXXX/dso/cam0/times.txt
         calib=PATH_TO_DMVIO/configs/tumvi_calib/camera02.txt
         gamma=PATH_TO_DMVIO/configs/tumvi_calib/pcalib.txt
         imuCalib=PATH_TO_DMVIO/configs/tumvi_calib/camchain.yaml
@@ -165,8 +166,9 @@ To run on your own dataset you need
 * an accurate camera calibration! For tips on calibration and the format of camera.txt see 
 [src/dso/README.md](src/dso/README.md).
 * to set the `mode=1` unless you have a photometric calibration (vignette.png and pcalib.txt).
-* a file times.txt which contains **exactly** one timestamp for each image in the image folder. Note that this file 
-  contains the timestamp twice, first in nanoseconds and then in seconds.
+* a file times.txt which contains **exactly** one timestamp for each image in
+  the image folder, or specified through the `tsFile` parameter. Note that this
+  file contains the timestamp twice, first in nanoseconds and then in seconds.
 
 When enabling IMU data you also need
 

--- a/src/dso/util/DatasetReader.h
+++ b/src/dso/util/DatasetReader.h
@@ -107,10 +107,11 @@ struct PrepImageItem
 class ImageFolderReader
 {
 public:
-	ImageFolderReader(std::string path, std::string calibFile, std::string gammaFile, std::string vignetteFile, bool use16BitPassed)
+	ImageFolderReader(std::string path, std::string calibFile, std::string gammaFile, std::string vignetteFile, bool use16BitPassed, std::string tsFile="")
 	{
 		this->path = path;
 		this->calibfile = calibFile;
+		this->tsFile = tsFile;
 		use16Bit = use16BitPassed;
 
 #if HAS_ZIPLIB
@@ -519,8 +520,14 @@ private:
 	inline void loadTimestamps()
 	{
 		std::ifstream tr;
-		std::string timesFile = path.substr(0,path.find_last_of('/')) + "/times.txt";
-		tr.open(timesFile.c_str());
+		std::string defaultFile = path.substr(0, path.find_last_of('/')) + "/times.txt";
+
+		if(this->tsFile == "")
+		{
+			this->tsFile = defaultFile;
+		}
+
+		tr.open(this->tsFile.c_str());
 		while(!tr.eof() && tr.good())
 		{
 			std::string line;
@@ -596,6 +603,7 @@ private:
 
 	std::string path;
 	std::string calibfile;
+	std::string tsFile;
 
 	bool isZipped;
 	bool use16Bit;

--- a/src/main_dmvio_dataset.cpp
+++ b/src/main_dmvio_dataset.cpp
@@ -55,6 +55,7 @@
 #include "IOWrapper/OutputWrapper/SampleOutputWrapper.h"
 
 std::string gtFile = "";
+std::string tsFile = "";
 std::string source = "";
 std::string imuFile = "";
 
@@ -369,6 +370,7 @@ int main(int argc, char** argv)
     settingsUtil->registerArg("end", end);
     settingsUtil->registerArg("imuFile", imuFile);
     settingsUtil->registerArg("gtFile", gtFile);
+    settingsUtil->registerArg("tsFile", tsFile);
     settingsUtil->registerArg("sampleoutput", useSampleOutput);
     settingsUtil->registerArg("reverse", reverse);
     settingsUtil->registerArg("use16Bit", use16Bit);
@@ -394,7 +396,7 @@ int main(int argc, char** argv)
     // hook crtl+C.
     boost::thread exThread = boost::thread(exitThread);
 
-    ImageFolderReader* reader = new ImageFolderReader(source, mainSettings.calib, mainSettings.gammaCalib, mainSettings.vignette, use16Bit);
+    ImageFolderReader* reader = new ImageFolderReader(source, mainSettings.calib, mainSettings.gammaCalib, mainSettings.vignette, use16Bit, tsFile);
     reader->loadIMUData(imuFile);
     reader->setGlobalCalibration();
 


### PR DESCRIPTION
It can be a bit annoying to modify your dataset directory to add the times.txt file inside of it.
Behaviors without this parameter remain the same (i.e., assuming times.txt is a sibling of the `files=` directory)